### PR TITLE
apply accel/gyro scaling and fix axes directions

### DIFF
--- a/src/madflight/imu/ICM4xxxx/MF_ICM45686.h
+++ b/src/madflight/imu/ICM4xxxx/MF_ICM45686.h
@@ -68,7 +68,6 @@ private:
     int _rate_hz = 100;
     int _interrupt_pin = 0;
 
-    // FIXME !!!!
     float acc_multiplier = 1.0;
     float gyro_multiplier = 1.0;
 
@@ -105,6 +104,33 @@ private:
         return ret;
     }
 
+    uint16_t _convertAccelScale(uint16_t range) {
+        // Accel: Supported full scale ranges are: 2, 4, 8, 16, 32 G (any other value defaults to 16 G).
+        uint16_t ret = 16;
+        if (range > 16) ret = 32;
+        else if (range > 8) ret = 16;
+        else if (range > 4) ret = 8;
+        else if (range > 2) ret = 4;
+        else if (range == 2) ret = 2;
+        return ret;
+    }
+
+    uint16_t _convertGyroScale(uint16_t range) {
+        // Gyro: Supported full scale ranges are: 16, 31, 62, 125, 250, 500, 1000, 2000, 4000 dps (any other value defaults to 2000 dps).
+        uint16_t ret = 2000;
+        if (range > 2000) ret = 4000;
+        else if (range > 1000) ret = 2000;
+        else if (range > 500) ret = 1000;
+        else if (range > 250) ret = 500;
+        else if (range > 125) ret = 250;
+        else if (range > 62) ret = 125;
+        else if (range > 31) ret = 62;
+        else if (range > 16) ret = 31;
+        else if (range == 16) ret = 16;
+        return ret;
+    }
+    
+
 public:
     MF_ICM45686(uint8_t intPin, Invensensev3_InterfaceSPI *iface)
         : _wrapped_imu(
@@ -113,6 +139,25 @@ public:
             iface->_freq) {
                 _interrupt_pin = intPin;
     }
+
+
+    // Converting raw values to physical values
+    // Madflight:
+    // Body frame is NED: x-axis North(front), y-axis East(right), z-axis Down
+    // ---
+    // float ax = 0; //"North" acceleration in G
+    // float gx = 0; //"North" rotation speed in deg/s
+
+    // in ICM-45686 driver https://github.com/tdk-invn-oss/motion.arduino.ICM45686/blob/main/examples/MicroROS_Publisher/MicroROS_Publisher.ino :
+    inline float_t _convert_accel(int16_t raw, uint16_t fs) {
+        return (float)raw * fs / INT16_MAX;
+    }
+
+    // raw is in degrees per second (dps)
+    inline float_t _convert_gyro(int16_t raw, uint16_t fs) {
+        return ((float)raw * fs) / INT16_MAX;
+    }
+    
 
     int begin(int gyro_scale_dps, int acc_scale_g, int rate_hz) {
         Serial.println("MF_ICM45686 :: initializing wrapped IMU ...");
@@ -133,11 +178,15 @@ public:
         Serial.flush();
         uint16_t adjusted_sample_rate = _convertSamplingRateHz(rate_hz);
         set_rate(adjusted_sample_rate);
-        // FIXME: use gyro_scale_dps & acc_scale_g !!!
-        // Accel - Full Scale Range = 16G
-        // Gyro - Full Scale Range = 2000 dps
+        // Lib: Supported full scale ranges are: 2, 4, 8, 16, 32 G (any other value defaults to 16 G).
+        int accelScaleG = _convertAccelScale(acc_scale_g);
+        acc_multiplier = _convert_accel((int16_t) 1, accelScaleG); // e.g. for 16G range, in Gs = 1 * 16 / INT16_MAX
         _wrapped_imu.startAccel(adjusted_sample_rate, 16);
-        _wrapped_imu.startGyro(adjusted_sample_rate, 2000);
+        // Lib: Supported full scale ranges are: 16, 31, 62, 125, 250, 500, 1000, 2000, 4000 dps (any other value defaults to 2000 dps).
+        // Sensor: The full-scale range of the gyro sensors may be digitally programmed to ±15.625, ±31.25, ±62.5, ±125, ±250, ±500, ±1000, ±2000 and ±4000 degrees per second (dps).
+        int gyroScaleDps = _convertGyroScale(gyro_scale_dps);
+        gyro_multiplier = _convert_gyro((int16_t) 1, gyroScaleDps); // 1dps = 1 * 2000 / INT16_MAX
+        _wrapped_imu.startGyro(adjusted_sample_rate, gyroScaleDps);
         // Wait IMU to start
         delay(100);
         _enableDataReadyInterrupt();
@@ -157,19 +206,25 @@ public:
     // gyro: direction of positive rotation by right hand rule, i.e. positive is: yaw right, roll right, pitch up
     void getMotion6NED(float *ax, float *ay, float *az, float *gx, float *gy, float *gz) {
         read6();
-        // FIXME: read temp
-        // FIXME: fix multipliers?
-        // FIXME: do we need to fix directions?
-        *ax = rawa[0] * acc_multiplier;
-        *ay = rawa[1] * acc_multiplier;
-        *az = rawa[2] * acc_multiplier;
-        *gx = rawg[0] * gyro_multiplier;
-        *gy = rawg[1] * gyro_multiplier;
-        *gz = rawg[2] * gyro_multiplier;
+        // FIXME: where can we use/report the temp data which was read?
+        // sensor orientation for acc/gyro is NWU
+        // acc result: gravitation force is positive in axis direction
+        // ICM-45686 Datasheet:
+        //   When the device is placed on a flat surface, it will measure 0g on the X- and Y- axes and +1g on the Z-axis.
+        //   The accelerometers’ scale factor is calibrated at the factory and is nominally independent of supply voltage. The fullscale range of the digital output can be adjusted to ±2g, ±4g, ±8g, ±16g and ±32g.
+        *ax = rawa[0] * -acc_multiplier; //-N = -N : FIXME: not sure why we have minus here, need to test (code was based on MPU driver)
+        *ay = rawa[1] * acc_multiplier;  //-E =  W
+        *az = rawa[2] * acc_multiplier;  //-D =  U
+        // expected gyro result: direction of positive rotation by right hand rule, i.e. positive is: roll right (X), pitch up (Y), yaw right (Z)
+        // gyro sensor positive:  X (roll right), Y (pitch down), Z (yaw left)
+        // ICM-45686 Datasheet: "detects rotation about the X-, Y-, and Z- Axes"
+        *gx = rawg[0] * gyro_multiplier; //N =  N
+        *gy = rawg[1] * -gyro_multiplier; //E = -W
+        *gz = rawg[2] * -gyro_multiplier; //D = -U
     }
 
     // FIXME: implement magnetometer support?
-
+    // P.S. Orientation of axes seem same as for MPU-xxxx, and is converted in getMotion6NED() function
     void read6() {        
         #ifdef MF_ICM45686_USE_IMU_FIFO
         inv_imu_fifo_data_t imu_data;
@@ -183,6 +238,7 @@ public:
         rawg[0] = imu_data.byte_16.gyro_data[0];
         rawg[1] = imu_data.byte_16.gyro_data[1];
         rawg[2] = imu_data.byte_16.gyro_data[2];
+        // Temperature in Degrees Centigrade = (TEMP_DATA / 128) + 25
         rawt = imu_data.byte_16.temp_data;
         #else
         inv_imu_sensor_data_t imu_data;

--- a/src/madflight/imu/imu.h
+++ b/src/madflight/imu/imu.h
@@ -14,6 +14,15 @@ MPU-6XXX and MPU-9XXX sensor family
 ===================================
 These are 6 or 9 axis sensors, with maximum sample rates: gyro 8 kHz, accel 4 kHz, and mag 100 Hz. The driver 
 configures gyro and accel with 1000 Hz sample rate (with on sensor 200 Hz low pass filter), and mag 100 Hz.
+
+===================================
+ICM-4xxxx sensors
+===================================
+Currently only ICM45686 is supported.
+This is a 6 axis sensor, with maximum sample rates of 6.4khz.
+Limitations: 
+- The underlying driver lib supports only one sensor instance
+- only via SPI + interupt; I2C can be added using the same driver lib
 ========================================================================================================================*/
 
 #pragma once
@@ -51,9 +60,11 @@ configures gyro and accel with 1000 Hz sample rate (with on sensor 200 Hz low pa
 
 //default settings
 #ifndef IMU_GYRO_DPS
+  // ICM45686 supports 4000dps as well
   #define IMU_GYRO_DPS 2000 //Full scale gyro range in deg/sec. Most IMUs support 250,500,1000,2000. Can use any value here, driver will pick next greater setting.
 #endif
 #ifndef IMU_ACCEL_G
+  // ICM45686 supports 32g as well
   #define IMU_ACCEL_G 16 //Full scale gyro accelerometer in G's. Most IMUs support 2,4,8,16. Can use any value here, driver will pick next greater setting.
 #endif
 


### PR DESCRIPTION
with `IMU_ALIGN_CW0`:

- [x] gyro: rotations in `pahrs`  are legit now (positive is: roll right (X), pitch up (Y), yaw right (Z))
```
# yaw right
roll:+7.6       pitch:+1.6      yaw:+46.9
# pitch down
roll:-2.8       pitch:-62.5     yaw:+15.7
# roll left
roll:-35.4      pitch:-12.2     yaw:+6.0
```
- [x] pacc (`ax` and `ay` looks fishy?)
```
# pacc:      Filtered accelerometer (expected: -2 to 2; x,y 0 when level, z 1 when level)
#     // x=North (forward), y=East (right), z=Down 
#    // acc: gravitation force is positive in axis direction

# az: level: OK
ax:+0.02        ay:+0.18        az:+0.98
# acc up: OK
ax:-0.43        ay:+0.57        az:+2.67

# ax: forward rotated to ground
ax:+1.02        ay:+0.04        az:-0.44

# ay: east/right rotated to ground
ax:+0.13        ay:+1.00        az:+0.09


# ax: move forward and break
ax:-0.06        ay:+0.17        az:+1.09
ax:-1.34        ay:+0.21        az:+1.53
ax:-1.56        ay:+0.68        az:-0.95
ax:+1.64        ay:+0.09        az:+2.26
ax:+0.69        ay:+0.13        az:+0.29
ax:+0.12        ay:+0.42        az:+0.89

# ay: move to the left and break
# y=East (right), acc: gravitation force is positive in axis direction 
ax:+0.08        ay:+0.29        az:+0.92
ax:-0.42        ay:+2.51        az:+1.06
ax:+1.37        ay:+0.05        az:+0.76
```